### PR TITLE
auth, user 커스텀 에러 구체화 후 적용, 내부 로직에서 기본 키 일관성 있게 사용하도록 수정

### DIFF
--- a/apps/auth/src/auth.controller.ts
+++ b/apps/auth/src/auth.controller.ts
@@ -71,7 +71,7 @@ export class AuthController {
   @Get('/logout')
   @UseGuards(JwtAuthGuard)
   async logout(@Req() req: RequestWithUser) {
-    await this.authService.logout(req.user.userId);
+    await this.authService.logout(req.user._id);
     return HttpResponse.success('로그아웃 되었습니다.');
   }
 

--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -8,11 +8,12 @@ import { JwtService } from '@nestjs/jwt';
 import TokenPayload from './interfaces/token-payload.interface';
 import { ConfigService } from '@nestjs/config';
 import {
+  InvalidTokenException,
   UserForbiddenException,
   UserUnauthorizedException,
   UserWithdrawnException,
 } from './exceptions/auth.exception';
-import { UserNotFoundException } from 'apps/auth/src/users/exceptions/users.exception';
+import { UserNotFoundException } from 'apps/auth/src/exceptions/users.exception';
 import * as argon2 from 'argon2';
 import { verifyPassword } from './common/utils/password.utils';
 import { State } from './@types/enums/user.enum';
@@ -198,7 +199,7 @@ export class AuthService {
     // 사용자가 유효한 리프레시 토큰을 제공했지만, 사용자가 저장한 토큰과 일치하지 않을 때 (탈취되었을 위험)
     if (!isRefreshTokenMatching) {
       await this.usersService.clearCurrentRefreshToken(userId);
-      throw new UserUnauthorizedException('Invalid refresh token.');
+      throw new InvalidTokenException('Invalid refresh token.');
     }
     return user;
   }

--- a/apps/auth/src/exceptions/auth.exception.ts
+++ b/apps/auth/src/exceptions/auth.exception.ts
@@ -11,6 +11,22 @@ export class UserUnauthorizedException extends BaseException {
   }
 }
 
+export class NotExpiredAccessTokenException extends BaseException {
+  constructor(message: string) {
+    super(
+      AuthExceptionEnum.NOT_EXPIRED_ACCESS_TOKEN,
+      HttpStatus.UNAUTHORIZED,
+      message,
+    );
+  }
+}
+
+export class InvalidTokenException extends BaseException {
+  constructor(message: string) {
+    super(AuthExceptionEnum.INVALID_TOKEN, HttpStatus.UNAUTHORIZED, message);
+  }
+}
+
 export class UserForbiddenException extends BaseException {
   constructor(message: string) {
     super(AuthExceptionEnum.USER_FORBIDDEN, HttpStatus.FORBIDDEN, message);

--- a/apps/auth/src/exceptions/auth.exception.ts
+++ b/apps/auth/src/exceptions/auth.exception.ts
@@ -38,3 +38,9 @@ export class UserWithdrawnException extends BaseException {
     super(AuthExceptionEnum.USER_WITHDRAWN, HttpStatus.FORBIDDEN, message);
   }
 }
+
+export class UserConflictException extends BaseException {
+  constructor(message: string) {
+    super(AuthExceptionEnum.USER_CONFLICT, HttpStatus.CONFLICT, message);
+  }
+}

--- a/apps/auth/src/exceptions/users.exception.ts
+++ b/apps/auth/src/exceptions/users.exception.ts
@@ -12,3 +12,19 @@ export class UserBadRequestException extends BaseException {
     super(UserExceptionEnum.USER_BAD_REQUEST, HttpStatus.BAD_REQUEST, message);
   }
 }
+
+export class UserIdDuplicateException extends BaseException {
+  constructor(message: string) {
+    super(UserExceptionEnum.USER_ID_DUPLICATE, HttpStatus.BAD_REQUEST, message);
+  }
+}
+
+export class UserNicknameDuplicateException extends BaseException {
+  constructor(message: string) {
+    super(
+      UserExceptionEnum.USER_NICKNAME_DUPLICATE,
+      HttpStatus.BAD_REQUEST,
+      message,
+    );
+  }
+}

--- a/apps/auth/src/interfaces/token-payload.interface.ts
+++ b/apps/auth/src/interfaces/token-payload.interface.ts
@@ -1,7 +1,8 @@
+import { ObjectId } from 'mongodb';
 import { Role } from '../@types/enums/user.enum';
 
 interface TokenPayload {
-  userId: string;
+  _id: ObjectId;
   role?: Role;
 }
 export default TokenPayload;

--- a/apps/auth/src/strategies/jwt.strategy.ts
+++ b/apps/auth/src/strategies/jwt.strategy.ts
@@ -20,7 +20,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
   }
   async validate(req: Request, payload: TokenPayload) {
-    const user = await this.usersService.findById(payload.userId);
+    const user = await this.usersService.findById(payload._id);
     req.user = user; // payload(request의 user 프로퍼티와 jwtService.verify()를 통해 검증해준 user 객체를 동일시해야함)
     return user;
   }

--- a/apps/auth/src/strategies/refresh.strategy.ts
+++ b/apps/auth/src/strategies/refresh.strategy.ts
@@ -25,7 +25,7 @@ export class RefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
     const isAccessTokenExpired =
       await this.authService.isAccessTokenExpired(expiredAccessToken);
     if (!isAccessTokenExpired) {
-      await this.usersService.clearCurrentRefreshToken(payload.userId);
+      await this.usersService.clearCurrentRefreshToken(payload._id);
       throw new NotExpiredAccessTokenException(
         'This is not an expired access token.',
       );
@@ -33,7 +33,7 @@ export class RefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
     const refreshToken = req.headers.authorization.split(' ')[1];
     return await this.authService.refreshTokenMatches(
       refreshToken,
-      payload.userId,
+      payload._id,
     );
   }
 }

--- a/apps/auth/src/strategies/refresh.strategy.ts
+++ b/apps/auth/src/strategies/refresh.strategy.ts
@@ -4,7 +4,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Request } from 'express';
 import TokenPayload from '../interfaces/token-payload.interface';
 import { AuthService } from '../auth.service';
-import { UserUnauthorizedException } from '../exceptions/auth.exception';
+import { NotExpiredAccessTokenException } from '../exceptions/auth.exception';
 import { UsersService } from '../users/users.service';
 
 @Injectable()
@@ -26,7 +26,7 @@ export class RefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
       await this.authService.isAccessTokenExpired(expiredAccessToken);
     if (!isAccessTokenExpired) {
       await this.usersService.clearCurrentRefreshToken(payload.userId);
-      throw new UserUnauthorizedException(
+      throw new NotExpiredAccessTokenException(
         'This is not an expired access token.',
       );
     }

--- a/apps/auth/src/users/users.controller.ts
+++ b/apps/auth/src/users/users.controller.ts
@@ -68,7 +68,7 @@ export class UsersController {
   @Delete()
   @UseGuards(JwtAuthGuard)
   async remove(@Req() req: RequestWithUser, @Res() res: Response) {
-    await this.usersService.remove(req.user.userId);
+    await this.usersService.remove(req.user._id);
     res.clearCookie('michiAccessToken', { path: '/' });
     res.clearCookie('michiRefreshToken', { path: '/' });
     res.json({ code: 200, message: '회원 탈퇴가 완료되었습니다.' });

--- a/apps/auth/src/users/users.service.ts
+++ b/apps/auth/src/users/users.service.ts
@@ -8,6 +8,7 @@ import {
   UserNicknameDuplicateException,
   UserNotFoundException,
 } from '../exceptions/users.exception';
+import { ObjectId } from 'mongodb';
 import { hashPassword, verifyPassword } from '../common/utils/password.utils';
 import { State } from '../@types/enums/user.enum';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -28,7 +29,7 @@ export class UsersService {
 
   // 아이디 존재 여부 체크
   async checkUserIdExists(userId: string): Promise<void> {
-    await this.findById(userId);
+    await this.findByUserId(userId);
   }
 
   // 닉네임 사용 가능 여부
@@ -48,8 +49,18 @@ export class UsersService {
     });
   }
 
+  // _id로 회원 정보 조회
+  async findById(_id: ObjectId): Promise<User> {
+    const user = await this.usersRepository.findOne({ _id });
+    if (!user) {
+      throw new UserNotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    return user;
+  }
+
   // userId로 회원 정보 조회
-  async findById(userId: string): Promise<User> {
+  async findByUserId(userId: string): Promise<User> {
     const user = await this.usersRepository.findOne({ userId });
     if (!user) {
       throw new UserNotFoundException('사용자를 찾을 수 없습니다.');
@@ -69,14 +80,14 @@ export class UsersService {
       const hashedPassword = await hashPassword(updateUserDto.newPassword);
 
       const updatedUser = await this.usersRepository.findOneAndUpdate(
-        { userId: user.userId },
+        { _id: user._id },
         { ...updateUserDto, password: hashedPassword },
       );
       return updatedUser;
     }
 
     return await this.usersRepository.findOneAndUpdate(
-      { userId: user.userId },
+      { _id: user._id },
       updateUserDto,
     );
   }
@@ -85,7 +96,7 @@ export class UsersService {
   async changePassword(changePasswordDto: ChangePasswordDto): Promise<void> {
     const { userId, newPassword } = changePasswordDto;
 
-    await this.findById(userId);
+    await this.findByUserId(userId);
     const hashedPassword = await hashPassword(newPassword);
 
     await this.usersRepository.findOneAndUpdate(
@@ -95,28 +106,32 @@ export class UsersService {
   }
 
   // 회원 탈퇴
-  async remove(userId: string): Promise<void> {
+  async remove(_id: ObjectId): Promise<void> {
     await this.usersRepository.findOneAndUpdate(
-      { userId },
-      { state: State.WITHDRAWN, deletedAt: new Date() },
+      { _id },
+      {
+        currentRefreshToken: null,
+        state: State.WITHDRAWN,
+        deletedAt: new Date(),
+      },
     );
   }
 
   // refresh token 저장
   async setCurrentRefreshToken(
     refreshToken: string,
-    userId: string,
+    _id: ObjectId,
   ): Promise<void> {
     const hashedRefreshToken = await argon2.hash(refreshToken);
     await this.usersRepository.findOneAndUpdate(
-      { userId },
+      { _id },
       { currentRefreshToken: hashedRefreshToken },
     );
   }
 
-  async clearCurrentRefreshToken(userId: string): Promise<void> {
+  async clearCurrentRefreshToken(_id: ObjectId): Promise<void> {
     await this.usersRepository.findOneAndUpdate(
-      { userId },
+      { _id },
       { currentRefreshToken: null },
     );
   }

--- a/apps/auth/src/users/users.service.ts
+++ b/apps/auth/src/users/users.service.ts
@@ -4,8 +4,10 @@ import { User } from './schemas/user.schema';
 import { UpdateUserDto } from './dto/update-user.dto';
 import {
   UserBadRequestException,
+  UserIdDuplicateException,
+  UserNicknameDuplicateException,
   UserNotFoundException,
-} from './exceptions/users.exception';
+} from '../exceptions/users.exception';
 import { hashPassword, verifyPassword } from '../common/utils/password.utils';
 import { State } from '../@types/enums/user.enum';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -20,7 +22,7 @@ export class UsersService {
   async checkUserId(userId: string): Promise<void> {
     const existingUser = await this.usersRepository.findOne({ userId });
     if (existingUser) {
-      throw new UserBadRequestException('존재하는 ID입니다.');
+      throw new UserIdDuplicateException('존재하는 ID입니다.');
     }
   }
 
@@ -33,7 +35,7 @@ export class UsersService {
   async checkNickname(nickname: string): Promise<void> {
     const existingUser = await this.usersRepository.findOne({ nickname });
     if (existingUser) {
-      throw new UserBadRequestException('존재하는 닉네임입니다.');
+      throw new UserNicknameDuplicateException('존재하는 닉네임입니다.');
     }
   }
 

--- a/libs/common/src/exceptions/exception.enum.ts
+++ b/libs/common/src/exceptions/exception.enum.ts
@@ -4,11 +4,15 @@ export enum UncatchedExceptionEnum {
 
 export enum UserExceptionEnum {
   USER_BAD_REQUEST = '0000',
+  USER_ID_DUPLICATE = '0001',
+  USER_NICKNAME_DUPLICATE = '0002',
   USER_NOT_FOUND = '0040',
 }
 
 export enum AuthExceptionEnum {
   USER_UNAUTHORIZED = '1010',
+  NOT_EXPIRED_ACCESS_TOKEN = '1011',
+  INVALID_TOKEN = '1012',
   USER_FORBIDDEN = '1030',
   USER_WITHDRAWN = '1031',
 }

--- a/libs/common/src/exceptions/exception.enum.ts
+++ b/libs/common/src/exceptions/exception.enum.ts
@@ -15,4 +15,5 @@ export enum AuthExceptionEnum {
   INVALID_TOKEN = '1012',
   USER_FORBIDDEN = '1030',
   USER_WITHDRAWN = '1031',
+  USER_CONFLICT = '1090',
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#14 #16 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- auth, user 커스텀 에러 처리 구체화
- 회원가입, 액세스 토큰 재발급 api에 적절한 에러 적용
- api 명세 수정
- auth, user 내부 로직에서 기본 키 일관성 있게 사용하도록 수정
- 회원가입 시 중복 가입 방지 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 프론트에서 효율적인 에러 처리를 할 수 있도록 에러를 좀 더 구체적으로 작성하였음. 프론트에서 우선적으로 statusCode를 확인해서 에러 여부를 판단하고, 겹치는 경우나 필요에 따라 errorCode(커스텀 에러 코드)를 추가로 확인해서 구체적인 처리를 수행하도록 함.
- auth, user 내부 로직에서 기본 키 일관성 있게 사용하도록 수정
  - 로그인 시에는 입력 받은 userId로 사용자 조회
  - 내부 로직에서 사용자 정보를 조회하거나 사용자와 관련된 다른 작업을 수행할 때는, MongoDB의 기본 키인 _id를 사용(성능 및 일관성 측면 고려)