### PR TITLE
유저 온라인 상태 표시 및 채팅 응답 변경

### DIFF
--- a/apps/auth/src/users/users.controller.ts
+++ b/apps/auth/src/users/users.controller.ts
@@ -15,10 +15,14 @@ import RequestWithUser from 'apps/auth/src/interfaces/request-with-user.interfac
 import { HttpResponse } from '@/common/dto/http-response';
 import { OneTimeAuthGuard } from 'apps/auth/src/guards/one-time-auth.guard';
 import { ChangePasswordDto } from './dto/change-password.dto';
+import {RedisCacheService} from "@/common";
 
 @Controller('users')
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly redisCacheService: RedisCacheService,
+  ) {}
 
   @Get('/id-check/:userId')
   async checkUserId(@Param('userId') userId: string) {
@@ -74,5 +78,12 @@ export class UsersController {
   async remove(@Req() req: RequestWithUser) {
     await this.usersService.remove(req.user._id);
     return HttpResponse.success('회원 탈퇴가 완료되었습니다.');
+  }
+
+  @Get('online')
+  @UseGuards(JwtAuthGuard)
+  async getOnlineUsers() {
+    const onlineUsers = await this.redisCacheService.getOnlineUsers();
+    return HttpResponse.success('온라인 사용자 목록이 조회되었습니다.', onlineUsers);
   }
 }

--- a/apps/chat/src/dto/chat-response.dto.ts
+++ b/apps/chat/src/dto/chat-response.dto.ts
@@ -1,15 +1,18 @@
 import { IsNotEmpty, IsString } from 'class-validator';
 import { Chat } from '../schemas/chat.schema';
-import { User } from '../../../auth/src/users/schemas/user.schema';
+import { User } from '@auth/users/schemas/user.schema';
+import {UserResponseDto} from "@auth/users/dto/user-response.dto";
 
 export class ChatResponseDto {
   @IsString()
   @IsNotEmpty()
   readonly message: string;
 
-  @IsString()
-  @IsNotEmpty()
-  readonly nickname: string;
+  readonly user: UserResponseDto;
+
+  // @IsString()
+  // @IsNotEmpty()
+  // readonly nickname: string;
 
   @IsString()
   @IsNotEmpty()
@@ -17,7 +20,8 @@ export class ChatResponseDto {
 
   constructor(chat: Chat, user: User) {
     this.message = chat.message;
-    this.nickname = user.nickname;
+    // this.nickname = user.nickname;
+    this.user = new UserResponseDto(user);
     this.createdAt = chat.createdAt.toISOString();
   }
 }

--- a/apps/chat/src/dto/chatroom-response.dto.ts
+++ b/apps/chat/src/dto/chatroom-response.dto.ts
@@ -1,5 +1,4 @@
 import { ChatRoomType } from '../@types/enums/chatroomtype.enum';
-import { User } from '../../../auth/src/users/schemas/user.schema';
 import { ChatRoom } from '../schemas/chatroom.schema';
 import { Types } from 'mongoose';
 
@@ -7,7 +6,6 @@ export class ChatroomResponseDto {
   readonly id: Types.ObjectId;
   readonly title: string;
   readonly type: ChatRoomType;
-  readonly owner: User;
   readonly lastMessage: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;

--- a/apps/chat/src/socket/socket.module.ts
+++ b/apps/chat/src/socket/socket.module.ts
@@ -10,6 +10,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { UserSchema } from '../../../auth/src/users/schemas/user.schema';
 import { ChatModule } from '../chat.module';
 import { ChatroomModule } from '../chatroom/chatroom.module';
+import {StatusGateway} from "@chat/socket/status.gateway";
 
 @Module({
   imports: [
@@ -24,6 +25,6 @@ import { ChatroomModule } from '../chatroom/chatroom.module';
     RedisCacheModule,
     MongooseModule.forFeature([{ name: 'User', schema: UserSchema }]),
   ],
-  providers: [SocketGateway, UsersService, UsersRepository],
+  providers: [SocketGateway, StatusGateway, UsersService, UsersRepository],
 })
 export class SocketModule {}

--- a/apps/chat/src/socket/status.gateway.ts
+++ b/apps/chat/src/socket/status.gateway.ts
@@ -1,0 +1,42 @@
+import {OnGatewayConnection, OnGatewayDisconnect, WebSocketGateway, WebSocketServer} from "@nestjs/websockets";
+import {Server, Socket} from "socket.io";
+import {Logger} from "@nestjs/common";
+import {UsersService} from "@auth/users/users.service";
+import {RedisCacheService} from "@/common";
+import {Status} from "@/common/@types/enums/common.enum";
+
+@WebSocketGateway({
+  namespace: '/socket/status',
+  cors: {
+    origin: '*',
+    credentials: true,
+  },
+})
+export class StatusGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server: Server;
+  private readonly logger = new Logger(StatusGateway.name);
+
+  constructor(
+    private readonly userService: UsersService,
+    private readonly redisCacheService: RedisCacheService,
+  ) {}
+
+  async handleConnection(client: Socket) {
+    const { userId } = client.handshake.query;
+    if (userId) {
+      await this.redisCacheService.setUserOnline(userId as string);
+      this.server.emit('userOnline', { userId, status: Status.ONLINE });
+      this.logger.log(`Client connected: ${userId}`);
+    }
+  }
+
+  async handleDisconnect(client: Socket) {
+    const { userId } = client.handshake.query;
+    if (userId) {
+      await this.redisCacheService.setUserOffline(userId as string);
+      this.server.emit('userOffline', { userId, status: Status.OFFLINE });
+      this.logger.log(`Client disconnected: ${userId}`);
+    }
+  }
+}

--- a/libs/common/src/@types/enums/common.enum.ts
+++ b/libs/common/src/@types/enums/common.enum.ts
@@ -1,0 +1,4 @@
+export enum Status {
+  ONLINE = 'online',
+  OFFLINE = 'offline',
+}

--- a/libs/common/src/redis-cache/redis-cache.service.ts
+++ b/libs/common/src/redis-cache/redis-cache.service.ts
@@ -17,4 +17,19 @@ export class RedisCacheService {
   async del(key: string): Promise<number> {
     return this.redisClient.del(key);
   }
+
+  /**
+   * 사용자 온라인 관련 메서드들
+   */
+  async setUserOnline(userId: string): Promise<void> {
+    await this.redisClient.sadd('online_users', userId);
+  }
+
+  async setUserOffline(userId: string): Promise<void> {
+    await this.redisClient.srem('online_users', userId);
+  }
+
+  async getOnlineUsers(): Promise<string[]> {
+    return this.redisClient.smembers('online_users');
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#24 유저들 온라인 상태 표시

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 웹소켓으로 사용자가 앱에 접속, 종료하는 것을 기록합니다
- 레디스를 사용해서 빠른 읽기, 쓰기가 가능합니다 -> 빈도가 많은 단순 작업
- `GET /users/online` API로 현재 온라인 상태인 유저 아이디를 조회할 수 있습니다
- 채팅 응답 DTO에 user 응답 DTO를 추가하고 입장, 퇴장의 응답을 {메시지, 유저 응답 DTO (입장 시에만)}로 변경했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?