### PR TITLE
docker, docker-compose 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+*.log.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1: Build
+FROM node:18-alpine AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Build the app
+RUN npm run build
+
+# Stage 2: Production
+FROM node:18-alpine AS base
+
+# Set working directory
+WORKDIR /app
+
+# Copy only the necessary files from the builder stage
+COPY --from=builder /michi/dist ./dist
+COPY --from=builder /michi/node_modules ./node_modules
+COPY --from=builder /michi/package*.json ./
+
+# Expose the port
+EXPOSE 5001
+
+# Start the app
+CMD ["npm", "run", "start:prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Stage 1: Build
 FROM node:18-alpine AS builder
 
+# Install Python and build-essential
+RUN apk add --no-cache python3 make g++
+
 # Set working directory
 WORKDIR /app
 
@@ -23,9 +26,9 @@ FROM node:18-alpine AS base
 WORKDIR /app
 
 # Copy only the necessary files from the builder stage
-COPY --from=builder /michi/dist ./dist
-COPY --from=builder /michi/node_modules ./node_modules
-COPY --from=builder /michi/package*.json ./
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package*.json ./
 
 # Expose the port
 EXPOSE 5001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  mongo:
+    image: mongo:latest
+    container_name: mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+    networks:
+      - backend
+
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    networks:
+      - backend
+
+volumes:
+  mongo-data:
+    driver: local
+  redis-data:
+    driver: local
+
+networks:
+  backend:
+    driver: bridge


### PR DESCRIPTION
# 구현 내용
컨테이너 배포를 위해 서버 컨테이너용 도커 파일, mongo, redis 도커 컴포즈 파일을 추가했습니다

- Dockerfile은 각 서버의 이미지를 빌드해서 AWS ECR로 올리는 용도 (일단 chat 서버만 테스트 중)
- mongo, redis는 기존 클라우드 방식을 사용하면 private subnet 안에 생길 컨테이너와 통신이 불가능하기 때문에 (앞단에 게이트웨이를 통과하면 가능할 것도 같은데 일단 너무 복잡할 것 같아용) 내부에서 컨테이너로 생성하는 빙식으로 생각중입니다

# 실행 방식
로컬에서 `docker-compose up -d` 로 `docker-compose.yml` 파일을 실행시킬 수 있습니다